### PR TITLE
Make graphs retina-ready

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ var html = `
   <style>
     * {
       font-weight: 400;
-      font-size: 13px;
+      font-size: 26px;
       font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
     }
 
@@ -25,6 +25,10 @@ var html = `
       fill: #dedede;
     }
 
+    .tick line {
+      stroke-width: 2px;
+    }
+
     .tick text {
       fill: #9ba1a6;
     }
@@ -32,11 +36,16 @@ var html = `
     .grid line {
       fill: none;
       stroke: #dedede;
+      stroke-width: 2px;
       shape-rendering: crispEdges;
     }
 
     .line, .legend line {
       fill: none;
+      stroke-width: 4px;
+    }
+
+    .chart-border {
       stroke-width: 2px;
     }
 
@@ -103,10 +112,10 @@ function generateChart(request, callback) {
     done: function(errors, window) {
       var svg = d3.select(window.document.querySelector('svg'));
 
-      var margin = {top: 50, right: 25, bottom: 25, left: 25},
+      var margin = {top: 100, right: 50, bottom: 50, left: 50},
           chartWidth = width - margin.left - margin.right,
           chartHeight = height - margin.top - margin.bottom,
-          legendWidth = 120;
+          legendWidth = 240;
 
       var x = d3.time.scale()
           .domain(d3.extent(columns))
@@ -153,8 +162,8 @@ function generateChart(request, callback) {
           .attr('transform', `translate(0, 0)`)
           .call(yAxis)
         .selectAll('text')
-          .attr('y', -13)
-          .attr('x', 5);
+          .attr('y', -26)
+          .attr('x', 10);
 
       var yGrid = yAxis
           .tickSize(chartWidth, 0, 0)
@@ -169,12 +178,15 @@ function generateChart(request, callback) {
           .orient('bottom')
           .ticks(3)
           .tickFormat(uppercaseFormat)
+          .innerTickSize(20)
           .outerTickSize(0);
 
       chart.append('g')
           .attr('class', 'x axis')
           .attr('transform', `translate(0, ${chartHeight})`)
-          .call(xAxis);
+          .call(xAxis)
+        .selectAll('text')
+          .attr('y', 30);
 
       chart.selectAll('path.line')
           .data(data)
@@ -187,7 +199,7 @@ function generateChart(request, callback) {
       if (legendLabels.length) {
         var legend = svg.append('g')
           .attr('class', 'legend')
-          .attr('transform', `translate(${margin.left + chartWidth - legendWidth * data.length - 10}, 23)`);
+          .attr('transform', `translate(${margin.left + chartWidth - legendWidth * data.length - 5}, 46)`);
 
         var legends = legend.selectAll('g')
           .data(data)
@@ -198,11 +210,11 @@ function generateChart(request, callback) {
         legends.append('circle')
             .attr('cx', 0)
             .attr('cy', 0)
-            .attr('r', 5)
+            .attr('r', 10)
             .style('fill', (d, i) => `#${lineColors[i] || '2ba8de'}`);
 
         legends.append('text')
-            .attr('x', 10)
+            .attr('x', 20)
             .attr('dy', '.32em')
             .attr('class', 'legend')
             .text((d, i) => legendLabels[i].toUpperCase())


### PR DESCRIPTION
The graphs don't look good on retina displays, such as iPhones. This makes the graphs retina-ready.

<img width="642" alt="screen shot 2016-03-14 at 5 23 42 pm" src="https://cloud.githubusercontent.com/assets/748504/13764128/85f97152-ea09-11e5-885a-4c53d5afe532.png">

@soul2197 
