### PR TITLE
Use different logic for highlighting the last x axis tick

### DIFF
--- a/server.js
+++ b/server.js
@@ -223,13 +223,14 @@ var renderChart = (request, window, callback) => {
     .innerTickSize(20)
     .outerTickSize(0);
 
-  chart.append('g')
+  var xTicks = chart.append('g')
     .attr('class', 'x axis')
     .attr('transform', `translate(0, ${chartHeight})`)
     .call(xAxis)
     .selectAll('text')
-    .attr('y', 30)
-    .attr('class', (_, i) => i === columnIndicies.length - 1 ? 'dark' : '');
+    .attr('y', 30);
+
+  d3.select(xTicks[0][xTicks.size() - 1]).attr('class', 'dark');
 
   chart.selectAll('path.line')
     .data(data)


### PR DESCRIPTION
I'm planning on adding a new strategy for specifying the number of ticks to use in a chart that will make the current method of highlighting the last label on the x axis more cumbersome.

This PR will highlight the last label on the x axis and does not depend on any other data.
